### PR TITLE
Improve robustness of `FStreamer::readString8 ()`

### DIFF
--- a/source/fstreamer.cpp
+++ b/source/fstreamer.cpp
@@ -587,9 +587,12 @@ TSize FStreamer::writeString8 (const char8* ptr, bool terminate)
 //------------------------------------------------------------------------
 TSize FStreamer::readString8 (char8* ptr, TSize size)
 {
+	if (size < 1)
+		return 0;
 	TSize i = 0;
+	TSize limit = size - 1;
 	char8 c = 0;
-	while (i < size)
+	while (i < limit)
 	{
 		if (readRaw ((void*)&c, sizeof (char)) != sizeof (char))
 			break;
@@ -598,14 +601,16 @@ TSize FStreamer::readString8 (char8* ptr, TSize size)
 		if (c == '\n' || c == '\0')
 			break;
 	}
-	if (c == '\n' && ptr[i - 2] == '\r')
-		ptr[i - 2] = 0;
-	if (i < size)
-		ptr[i] = 0;
-	else
-		ptr[size - 1] = 0;
+	if (c == '\n')
+	{
+		if (i > 1 && ptr[i - 2] == '\r')
+			i = i - 2;
+		else
+			i = i - 1;
+	}
+	ptr[i] = 0;
 
-	return strlen (ptr);
+	return i;
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
1. If the upcoming byte in the stream was a Linux-style line break (`'\n'`) then the original implementation attempted to read a byte before the beginning of the destination buffer when looking for a preceding `'\r'`.

2. No matter how the `while` loop stops, the location of the terminating zero is known, so there's no need to call `strlen()` to find it again.

3. Windows-style line breaks were trimmed from the end of the read string, but Linux-style line breaks were kept. Now they are handled consistently.

4. Handle `size < 1` mistakes gracefully.

5. When the string in the stream was longer than the buffer, then the original implementation would overwrite the last read character with the terminating zero.