### PR TITLE
Remove warnings that cannot be silenced on Linux

### DIFF
--- a/source/fstring.cpp
+++ b/source/fstring.cpp
@@ -293,7 +293,6 @@ static inline int strnicmp16 (const Steinberg::char16* s1, const Steinberg::char
 //-----------------------------------------------------------------------------
 static inline int sprintf16 (Steinberg::char16* wcs, const Steinberg::char16* format, ...)
 {
-#warning DEPRECATED No Linux implementation
     assert(false && "DEPRECATED No Linux implementation");
 	return 0;
 }
@@ -317,7 +316,6 @@ static inline int vsnwprintf (Steinberg::char16* wcs, size_t maxlen,
 //-----------------------------------------------------------------------------
 static inline Steinberg::char16* strrchr16 (const Steinberg::char16* str, Steinberg::char16 c)
 {
-#warning DEPRECATED No Linux implementation
     assert(false && "DEPRECATED No Linux implementation");
 	return nullptr;
 }
@@ -1595,7 +1593,6 @@ char16 ConstString::toLower (char16 c)
 		}
 		return c;
 	#elif SMTG_OS_LINUX
-	#warning DEPRECATED No Linux implementation
 	assert(false && "DEPRECATED No Linux implementation");
 		return c;
 	#else
@@ -1624,7 +1621,6 @@ char16 ConstString::toUpper (char16 c)
 		}
 		return c;
     #elif SMTG_OS_LINUX
-	#warning DEPRECATED No Linux implementation
 	assert(false && "DEPRECATED No Linux implementation");
 		return c;
 	#else
@@ -1923,7 +1919,6 @@ int32 ConstString::multiByteToWideString (char16* dest, const char8* source, int
 	}
 	else
 	{
-#warning DEPRECATED No Linux implementation
 		assert(false && "DEPRECATED No Linux implementation");
 	}
 
@@ -2004,7 +1999,6 @@ int32 ConstString::wideStringToMultiByte (char8* dest, const char16* wideString,
 	}
 	else
 	{
-#warning DEPRECATED No Linux implementation
 		assert(false && "DEPRECATED No Linux implementation");
 	}
 	return result;


### PR DESCRIPTION
These changes were made to facilitate inclusion in JUCE.

Some compilers make it difficult to completely silence `#warning` directives. Instead of removing the #warning, perhaps the function declarations could be decorated with `[[deprecated]]` annotations.