### PR TITLE
Fix warnings in fstring.cpp

### DIFF
--- a/source/fstring.cpp
+++ b/source/fstring.cpp
@@ -3378,9 +3378,9 @@ String& String::printFloat (double value, uint32 maxPrecision)
 	// trim trail zeros
 	for (int32 i = length () - 1; i >= 0; i--)
 	{
-		if (isWide && testChar16 (i, '0') || testChar8 (i, '0'))
+		if ((isWide && testChar16 (i, '0')) || testChar8 (i, '0'))
 			remove (i);
-		else if (isWide && testChar16(i,'.') || testChar8(i, '.'))
+		else if ((isWide && testChar16 (i,'.')) || testChar8 (i, '.'))
 		{
 			remove(i);
 			break;
@@ -3566,10 +3566,12 @@ bool String::fromVariant (const FVariant& var)
 
 		case FVariant::kObject:
 			if (auto string = ICast<Steinberg::IString> (var.getObject ()))
+			{
 				if (string->isWideString ())
 					assign (string->getText16 ());
 				else
 					assign (string->getText8 ());
+			}
 			return true;
 
 		default:


### PR DESCRIPTION
Xcode 15.4 clang identifies these warnings. Here is the fix.